### PR TITLE
Improve synthetic metrics and include rules

### DIFF
--- a/install/assets/prometheus/rules/lifecycle.rules.yaml
+++ b/install/assets/prometheus/rules/lifecycle.rules.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: monitor-project-lifecycle-rules
+  labels:
+    role: prometheus-rulefiles
+    prometheus: k8s
+data:
+  lifecycle.rules.yaml: |+
+    groups:
+    - name: project.lifecycle.rules
+      rules:
+      - record: app_create_latency_seconds:quantile
+        expr: 'histogram_quantile(0.99, rate(app_create_latency_seconds_bucket[10m]))'
+        labels:
+          quantile: "0.99"
+      - alert: DeployLatencyHigh
+        expr: 'app_create_latency_seconds:quantile{quantile="0.99",step="deploy"} > 200'
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          description: End user lifecycle {{$labels.step}} step has a 99th percentile latency of {{$value}} seconds

--- a/install/hack/deploy
+++ b/install/hack/deploy
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 oc apply -f manifests
+oc apply -f assets/prometheus/rules


### PR DESCRIPTION
Improve synthetic metrics by producing simple histogram data that very rougly
approximates the lifecycle data we want to measure. Incorporate some example
rules to be automatically read by Prometheus, including an example alert which
will start firing soon after startup.