### PR TITLE
Changed the name of the RPM and image per RCM request.

### DIFF
--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -34,7 +34,7 @@ readonly OS_TEST_TARGETS=( )
 # os::build::get_product_vars exports variables that we expect to change
 # depending on the distribution of Origin
 function os::build::get_product_vars() {
-  export OS_BUILD_LDFLAGS_IMAGE_PREFIX="${OS_IMAGE_PREFIX:-"openshift/origin"}"
+  export OS_BUILD_LDFLAGS_IMAGE_PREFIX="${OS_IMAGE_PREFIX:-"openshift/openshift"}"
   export OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS="${OS_BUILD_LDFLAGS_DEFAULT_IMAGE_STREAMS:-"centos7"}"
 }
 
@@ -142,11 +142,11 @@ function os::util::list_go_deps() {
 
 # OS_ALL_IMAGES is the list of images built by os::build::images.
 readonly OS_ALL_IMAGES=(
-  openshift/origin-monitor-project-lifecycle
+  openshift/openshift-monitor-project-lifecycle
 )
 
 # os::build::images builds all images in this repo.
 function os::build::images() {
-  tag_prefix="${OS_IMAGE_PREFIX:-"openshift/origin"}"
-  os::build::image "${tag_prefix}-monitor-project-lifecycle" images/origin-monitor-project-lifecycle
+  tag_prefix="${OS_IMAGE_PREFIX:-"openshift/openshift"}"
+  os::build::image "${tag_prefix}-monitor-project-lifecycle" images/openshift-monitor-project-lifecycle
 }

--- a/images/openshift-monitor-project-lifecycle/Dockerfile
+++ b/images/openshift-monitor-project-lifecycle/Dockerfile
@@ -1,9 +1,9 @@
 #
-# The standard name for this image is openshift/monitor-project-lifecycle
+# The standard name for this image is openshift/openshift-monitor-project-lifecycle
 #
 FROM openshift/origin-base
 
-RUN INSTALL_PKGS="origin-monitor-project-lifecycle" && \
+RUN INSTALL_PKGS="openshift-monitor-project-lifecycle" && \
     yum --enablerepo=origin-local-release install -y ${INSTALL_PKGS} && \
     rpm -V ${INSTALL_PKGS} && \
     yum clean all

--- a/install/manifests/lifecycle-app.yaml
+++ b/install/manifests/lifecycle-app.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: monitor-project-lifecycle
         # This image setup is just for local development.
-        image: openshift/origin-monitor-project-lifecycle
+        image: openshift/openshift-monitor-project-lifecycle
         imagePullPolicy: IfNotPresent
         ports:
         - name: web

--- a/monitor-project-lifecycle.spec
+++ b/monitor-project-lifecycle.spec
@@ -49,7 +49,7 @@
 %global golang_version 1.8.1
 %{!?version: %global version 0.0.1}
 %{!?release: %global release 1}
-%global package_name origin-monitor-project-lifecycle
+%global package_name openshift-monitor-project-lifecycle
 %global product_name OpenShift Monitor Project Lifecycle
 %global import_path github.com/openshift/monitor-project-lifecycle
 


### PR DESCRIPTION
Changed the name of the RPM and image per RCM request.

- [x] Changed the name of the RPM
- [x] Changed the default name of the Image
- [x] Changed the image referenced in the lifecycle-app.yaml OpenShift template.
- [x] `make` success
- [x] `make build-rpms` success
```
_output/local/releases/rpms/openshift-monitor-project-lifecycle-3.9.0-0.alpha.0.11.7056c70.el7.x86_64.rpm
```
- [x] `make build-images` success
```
openshift/openshift-monitor-project-lifecycle   7056c70             080a4e6a80b2        13 seconds ago      423 MB
openshift/openshift-monitor-project-lifecycle   latest              080a4e6a80b2        13 seconds ago      423 MB
```