### PR TITLE
Fix issue #24: Remove all monitoring namespaces

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -359,6 +359,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "589b1d427dbe746050c312000310dd51f74a0b7c6642fb72b5225dcaa920f9c3"
+  inputs-digest = "737fad18df1ac29265fc2a19cb6001a6f7dd87d3566ba8e84e2831a68249d60e"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Fix issue #24: Remove all monitoring namespaces

- [x] Add label to namespace for easy lookup
- [x] Add annotation to namespace to ensure ownership
- [x] Remove all monitoring projects before run
- [x] Remove all monitoring projects after run
- [x] Only delete projects if they contain our label and annotation
- [x] Test code against cluster
- [x] Test that build still works using: OS_BUILD_ENV_PRESERVE=_output/local/bin hack/env make build-images
