### PR TITLE
Use os::golang::verify_go_version function for verify go version

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -83,12 +83,7 @@ function os::build::setup_env() {
   # a version number, so we skip this check on Travis.  It's unnecessary
   # there anyway.
   if [[ "${TRAVIS:-}" != "true" ]]; then
-    local go_version
-    go_version=($(go version))
-    if [[ "${go_version[2]}" < "${OS_REQUIRED_GO_VERSION}" ]]; then
-      os::log::fatal "Detected Go version: ${go_version[*]}.
-Builds require Go version ${OS_REQUIRED_GO_VERSION} or greater."
-    fi
+    os::golang::verify_go_version
   fi
   # For any tools that expect this to be set (it is default in golang 1.6),
   # force vendor experiment.


### PR DESCRIPTION
Build failed when I use golang 1.11

➜  monitor-project-lifecycle git:(master) make
hack/build-go.sh  
[FATAL] Detected Go version: go version go1.11 darwin/amd64.
[FATAL] Builds require Go version go1.9 or greater.
[ERROR] hack/build-go.sh exited with code 1 after 00h 00m 00s
make: *** [all] Error 1

This update allow us to use PERMISSIVE_GO=y to bypass the go version check